### PR TITLE
Add "Answered" mouseover text to checkmarks on discussion topics.

### DIFF
--- a/templates/discuss/index.html
+++ b/templates/discuss/index.html
@@ -41,7 +41,7 @@
 <div class="discussion-topic{% if topic.status == 'HID' %} fade-out{% endif %}" id="topic-{{ topic.pk }}">
 	<h3><a href="{% url "discuss.views.view_topic" course_slug=course.slug topic_slug=topic.slug %}">
 		{% if topic.pinned %}<i class="fa fa-tag"></i>{% endif %}
-		{% if topic.status == 'ANS' %}<i class="fa fa-check"></i>{% endif %}
+		{% if topic.status == 'ANS' %}<i class="fa fa-check" title="Answered"></i>{% endif %}
 		{{ topic.title }}
 	</a></h3>
 	<div>

--- a/templates/discuss/topic.html
+++ b/templates/discuss/topic.html
@@ -2,7 +2,7 @@
 {% block title %}Discussion: {{ topic.title }}{% endblock %}
 {% block h1 %}Discussion: {{ topic.title }}
 	{% if topic.pinned %}<i class="fa fa-tag"></i>{% endif %}
-    {% if topic.status == 'ANS' %}<i class="fa fa-check"></i>{% endif %}
+    {% if topic.status == 'ANS' %}<i class="fa fa-check" title="Answered"></i>{% endif %}
 {% endblock %}
 
 {% block headextra %}


### PR DESCRIPTION
This makes the meaning of the checkmark more clear for people who don't realize that topics could be marked at answered.
