### PR TITLE
Replace reference to obsolete Google Reader with Feedly

### DIFF
--- a/templates/dashboard/calendar_url.html
+++ b/templates/dashboard/calendar_url.html
@@ -13,7 +13,7 @@ Activating the external calendar may cause privacy concerns.  You will be given 
 <ul>
 <li>The generated URL will contain a long string of random characters that would be essentially impossible to guess.</li>
 <li>This URL can be <strong>accessed with no further authentication</strong> (username or password).  It is your responsibility to keep this URL private.</li>
-<li><strong>Be careful with social networking features</strong> (like Google Reader's ability to &ldquo;share&rdquo; items).  These will reveal the details of your feed and likely give others the information they need to view any of your news stories.</li>
+<li><strong>Be careful with social networking features</strong> (like Feedly's ability to &ldquo;share&rdquo; items).  These will reveal the details of your feed and likely give others the information they need to view any of your news stories.</li>
 <li>Your feed can be deactivated or be moved to a different URL at any time.</li>
 </ul>
 

--- a/templates/dashboard/config.html
+++ b/templates/dashboard/config.html
@@ -53,10 +53,10 @@
 <blockquote>
 <p><a href="{% url "news:atom_feed" token=newstoken userid=userid %}">{{server_url}}{% url "news:atom_feed" token=newstoken userid=userid %}</a></p>
 </blockquote>
-<p>You can subscribe to this feed URL in a feed reader like <a href="http://www.google.com/reader/">Google Reader</a> or another <a href="http://en.wikipedia.org/wiki/Comparison_of_feed_aggregators">feed aggregator</a> (that supports Atom&nbsp;2.0 feeds).</p>
+<p>You can subscribe to this feed URL in a feed reader like <a href="https://feedly.com/">Feedly</a> or another <a href="http://en.wikipedia.org/wiki/Comparison_of_feed_aggregators">feed aggregator</a> (that supports Atom&nbsp;2.0 feeds).</p>
 {% else %}
 <p>You do not currently have the external news feed configured.</p>
-<p>The news feed can be used to subscribe to your news items (like new grades) in a feed reader like <a href="http://www.google.com/reader/">Google Reader</a> or another <a href="http://en.wikipedia.org/wiki/Comparison_of_feed_aggregators">feed aggregator</a> (that supports Atom&nbsp;2.0 feeds).</p>
+<p>The news feed can be used to subscribe to your news items (like new grades) in a feed reader like <a href="https://feedly.com/">Feedly</a> or another <a href="http://en.wikipedia.org/wiki/Comparison_of_feed_aggregators">feed aggregator</a> (that supports Atom&nbsp;2.0 feeds).</p>
 {% endif %}
 
 <h2 id="extcalendar">External Calendar</h2>

--- a/templates/dashboard/news_url.html
+++ b/templates/dashboard/news_url.html
@@ -13,7 +13,7 @@ Activating the external news feed may cause privacy concerns.  You will be given
 <ul>
 <li>The generated URL will contain a long string of random characters that would be essentially impossible to guess.</li>
 <li>This URL can be <strong>accessed with no further authentication</strong> (username or password).  It is your responsibility to keep this URL private.</li>
-<li><strong>Be careful with social networking features</strong> (like Google Reader's ability to &ldquo;share&rdquo; news stories).  These will reveal the details of your feed and likely give others the information they need to view any of your news stories.</li>
+<li><strong>Be careful with social networking features</strong> (like Feedly's ability to &ldquo;share&rdquo; news stories).  These will reveal the details of your feed and likely give others the information they need to view any of your news stories.</li>
 <li>Your feed can be deactivated or be moved to a different URL at any time.</li>
 </ul>
 


### PR DESCRIPTION
Replace the references to Google Reader (now discontinued) to another RSS feed aggregator, Feedly.