### PR TITLE
Fix typos in the doc templates

### DIFF
--- a/templates/docs/doc_calc_numeric.html
+++ b/templates/docs/doc_calc_numeric.html
@@ -109,11 +109,11 @@
 
 
 <h2 id="calculating">Calculating Grades</h2>
-<p>Grades are <strong>not</strong> calculated/recalcualted automatically: click the &ldquo;Calculate all&rdquo; button on the activity info page.</p>
+<p>Grades are <strong>not</strong> calculated/recalculated automatically: click the &ldquo;Calculate all&rdquo; button on the activity info page.</p>
 
 <h2 id="override">Overriding Calculated Grades</h2>
 <p>If you would like to manually enter grades for individual students (who have a special-case grading scheme for example), you can click on their grade in the grade list. Enter their grade and change the grade status to &ldquo;graded&rdquo; (or &ldquo;excused&rdquo; or &ldquo;academic dishonesty&rdquo;).</p>
-<p>Only grades that were previously calcuated will be changed when you click &ldquo;Calculate all&rdquo;. Manually-entered grades with a different status will be left as they are.</p>
+<p>Only grades that were previously calculated will be changed when you click &ldquo;Calculate all&rdquo;. Manually-entered grades with a different status will be left as they are.</p>
 
 
 

--- a/templates/docs/doc_discipline.html
+++ b/templates/docs/doc_discipline.html
@@ -11,7 +11,7 @@
 {% block content %}
 
 <p>
-The academic dishonesty features in {{ CourSys }} are designed to autmate and simplify the handling and management of dishonesty cases to the greatest extent possible.
+The academic dishonesty features in {{ CourSys }} are designed to automate and simplify the handling and management of dishonesty cases to the greatest extent possible.
 Of course, instructors must be aware of <a href="http://www.sfu.ca/policies/gazette/student.html">the University's policies on student discipline</a>.
 The system is designed to make following the policies as easy as possible, but can't replace basic knowledge of their workings.
 </p>


### PR DESCRIPTION
Changed in templates/docs/doc_calc_numeric.html:
- "recalcualted" -> "recalculated"
- "calcuated" -> "calculated"

Changed in templates/docs/doc_discipline.html:
- "autmate" -> "automate"