### PR TITLE
Round Up Total Pay for TA Contracts

### DIFF
--- a/tacontracts/models.py
+++ b/tacontracts/models.py
@@ -2,6 +2,7 @@
 import datetime
 import decimal
 import os
+import math
 # Django
 from django.db import models, transaction
 # Third Party
@@ -432,7 +433,7 @@ class TAContract(models.Model):
         if len(self.course.all()) == 0:
             return decimal.Decimal(0)
         else:
-            return decimal.Decimal(self.total_bu * self.pay_per_bu)
+            return decimal.Decimal(math.ceil(self.total_bu * self.pay_per_bu))
 
     @property
     def biweekly_pay(self):

--- a/tacontracts/tests.py
+++ b/tacontracts/tests.py
@@ -80,7 +80,7 @@ class TAContractTestCase(TestCase):
                               title="Test Contract Category",
                               hours_per_bu=decimal.Decimal("42"),
                               holiday_hours_per_bu=decimal.Decimal("1.1"),
-                              pay_per_bu=decimal.Decimal("100.00"),
+                              pay_per_bu=decimal.Decimal("125.00"),
                               scholarship_per_bu=decimal.Decimal("25.00"),
                               bu_lab_bonus=decimal.Decimal("0.17"))
         category.save()
@@ -148,11 +148,11 @@ class TAContractTestCase(TestCase):
 
     def test_total_pay(self):
         """
-        5.17 * 100/BU = $517.00
+        5.17 * 125/BU = $646.25. Rounded up, $647.00.
         """
         contract = self.get_contract()
         self.assertEqual(type(contract.total_pay), type(decimal.Decimal("0")))
-        self.assertEqual(contract.total_pay, decimal.Decimal("517.00"))
+        self.assertEqual(contract.total_pay, decimal.Decimal("647.00"))
 
     def test_scholarship_pay(self):
         """
@@ -165,11 +165,11 @@ class TAContractTestCase(TestCase):
 
     def test_payperiods_and_biweekly(self):
         """
-        Okay, so, $517 total_pay divided across 2.5 payperiods should be...
+        Okay, so, $647 total_pay divided across 2.5 payperiods should be...
         """
         contract = self.get_contract()
         self.assertEqual(contract.payperiods, decimal.Decimal("2.5"))
-        self.assertEqual(contract.biweekly_pay, decimal.Decimal("206.80"))
+        self.assertEqual(contract.biweekly_pay, decimal.Decimal("258.8"))
         self.assertEqual(contract.biweekly_scholarship, decimal.Decimal("50"))
     
     def test_tacourse_exists(self):


### PR DESCRIPTION
**Reason:**

Requirements have changed for TA contracts and total pay must now be rounded **up** to the nearest whole number.

**Notes:**

See below before and after shots of the ta contracts module and one example contract. Total pay is always rounded up (eg. 100.00 -> 100.00, 100.01 -> 101.00).

The total on the page which shows all contracts will then usually be a whole number as well, except for in the noted and unusual case that a scholarship amount is not a whole number (since total scholarship + total pay = total).

This will also reflect correctly when printing ta contracts, either as an administrator or as a receiver of the contract.

The TA contract test case has been modified to watch for this new requirement.

**Before:**

![Before-Snap1](https://user-images.githubusercontent.com/17059664/100034032-2bf67c00-2db0-11eb-9683-fa2b03118507.PNG)
-------------------------------------
![Before-Snap2](https://user-images.githubusercontent.com/17059664/100034033-2c8f1280-2db0-11eb-85c1-32aa77ac3eb7.PNG)

**After:**

![After-Snap1](https://user-images.githubusercontent.com/17059664/100034041-31ec5d00-2db0-11eb-9e76-2f02098b6636.PNG)
-------------------------------------
![After-Snap2](https://user-images.githubusercontent.com/17059664/100034042-3284f380-2db0-11eb-834a-457f7b7a7d96.PNG)
