### PR TITLE
Add Appointment Dates to Hiring Semester Defaults

### DIFF
--- a/tacontracts/forms.py
+++ b/tacontracts/forms.py
@@ -37,6 +37,8 @@ class HiringSemesterForm(forms.ModelForm):
                     'deadline_for_acceptance': CalendarWidget,
                     'pay_start': CalendarWidget,
                     'pay_end': CalendarWidget,
+                    'appointment_start': CalendarWidget,
+                    'appointment_end': CalendarWidget,
                     'payperiods': GuessPayperiodsWidget,
                 }
 

--- a/tacontracts/models.py
+++ b/tacontracts/models.py
@@ -105,6 +105,8 @@ class HiringSemester(models.Model):
     semester = models.ForeignKey(Semester, on_delete=models.PROTECT)
     unit = models.ForeignKey(Unit, on_delete=models.PROTECT)
     deadline_for_acceptance = models.DateField()
+    appointment_start = models.DateField()
+    appointment_end = models.DateField()
     pay_start = models.DateField()
     pay_end = models.DateField()
     payperiods = models.DecimalField(max_digits=4, decimal_places=2,

--- a/tacontracts/views.py
+++ b/tacontracts/views.py
@@ -129,6 +129,8 @@ def setup_semester(request, semester):
         'semester':semester,
         'pay_start':semester.start, 
         'pay_end':semester.end, 
+        'appointment_start':semester.start, 
+        'appointment_end':semester.end, 
         'payperiods': 6})
     return render(request, 'tacontracts/new_semester.html', {
                   'form':form})
@@ -375,8 +377,8 @@ def new_contract(request, unit_slug, semester):
     else:
         form = TAContractForm(hiring_semester, initial={
             'deadline_for_acceptance':hiring_semester.deadline_for_acceptance,
-            'appointment_start':hiring_semester.pay_start,
-            'appointment_end':hiring_semester.pay_end,
+            'appointment_start':hiring_semester.appointment_start,
+            'appointment_end':hiring_semester.appointment_end,
             'pay_start':hiring_semester.pay_start,
             'pay_end':hiring_semester.pay_end,
             'payperiods':hiring_semester.payperiods


### PR DESCRIPTION
Reason: Appointment Start/Appointment End and Pay Start/Pay End ranges are no longer always the same anymore. It will save time to add Appointment Start and Appointment End dates as hiring semester defaults so that they don't have to change the fields manually for each new contract.

Notes: For migration, any DateField for any already existing hiring semesters should be fine as default when prompted (I just used today's date for both new fields) This will only be useful for future hiring semesters. 

See new Appointment Start/Appointment End fields below:

![Capture2](https://user-images.githubusercontent.com/17059664/103573176-ab34a080-4e82-11eb-8fce-676f97ad78cc.PNG)
