### PR TITLE
Add ID to Visa Table, Separate Out Completed Form Submissions, Alter TA Offer Letter Remarks, Remove Inactive Fields/Sheets form Completed Forms Export

### DIFF
--- a/dashboard/letters.py
+++ b/dashboard/letters.py
@@ -973,10 +973,11 @@ class TAForm(object):
     CONTENT_SIZE = 12
     NOTE_STYLE = ParagraphStyle(name='Normal',
                                 fontName='Helvetica',
-                                fontSize=9,
+                                fontSize=7,
                                 leading=10,
                                 alignment=TA_LEFT,
                                 textColor=black)
+                        
 
     def __init__(self, outfile):
         """
@@ -1238,10 +1239,11 @@ class TAForm(object):
         self.c.drawString(114*mm, 125*mm, "THESE RATES INCLUDE 4%")
         self.c.drawString(114*mm, 123*mm, "VACATION PAY")
 
+        # As usual, work will be assigned using the Time Use Guidelines, and you are expected to track and report your hours in the normal manner.
         # remarks
         self.c.setFont("Helvetica-Bold", self.LABEL_SIZE)
-        self.c.drawString(1*mm, 103*mm, "REMARKS")
-        f = Frame(3*mm, 82*mm, main_width - 6*mm, 22*mm) #, showBoundary=1
+        self.c.drawString(1*mm, 106*mm, "REMARKS")
+        f = Frame(3*mm, 79*mm, main_width - 6*mm, 27*mm) #, showBoundary=1
         notes = []
         notes.append(Paragraph(remarks, style=self.NOTE_STYLE))
         f.addFromList(notes, self.c)

--- a/onlineforms/models.py
+++ b/onlineforms/models.py
@@ -468,12 +468,11 @@ class Form(models.Model, _FormCoherenceMixin):
         headers = []
         data = []
 
-        # find all sheets (in a sensible order: deleted last)
+        # find all active sheets
         sheets = Sheet.objects.filter(form__original_id=self.original_id).order_by('order', '-created_date')
         active_sheets = [s for s in sheets if s.active]
-        inactive_sheets = [s for s in sheets if not s.active]
         sheet_info = collections.OrderedDict()
-        for s in itertools.chain(active_sheets, inactive_sheets):
+        for s in itertools.chain(active_sheets):
             if s.original_id not in sheet_info:
                 sheet_info[s.original_id] = {
                     'title': s.title,
@@ -481,13 +480,13 @@ class Form(models.Model, _FormCoherenceMixin):
                     'is_initial': s.is_initial,
                 }
 
-        # find all fields in each of those sheets (in a equally-sensible order)
+        # find all active fields in each of those sheets
         fields = Field.objects.filter(sheet__form__original_id=self.original_id).select_related('sheet') \
             .order_by('order', '-created_date').select_related('sheet')
 
-        active_fields = [f for f in fields if f.active and f.sheet.active]
-        inactive_fields = [f for f in fields if not (f.active and f.sheet.active)]
-        for f in itertools.chain(active_fields, inactive_fields):
+        # only show field if both sheet and field is active
+        active_fields = [f for f in fields if f.active]
+        for f in itertools.chain(active_fields):
             if not FIELD_TYPE_MODELS[f.fieldtype].in_summary:
                 continue
             info = sheet_info[f.sheet.original_id]

--- a/onlineforms/models.py
+++ b/onlineforms/models.py
@@ -485,7 +485,7 @@ class Form(models.Model, _FormCoherenceMixin):
             .order_by('order', '-created_date').select_related('sheet')
 
         # only show field if both sheet and field is active
-        active_fields = [f for f in fields if f.active]
+        active_fields = [f for f in fields if f.active and f.sheet.active]
         for f in itertools.chain(active_fields):
             if not FIELD_TYPE_MODELS[f.fieldtype].in_summary:
                 continue

--- a/onlineforms/urls.py
+++ b/onlineforms/urls.py
@@ -25,6 +25,7 @@ forms_patterns = [
     url(r'^admin/assign-nonsfu$', onlineforms_views.admin_assign_any_nonsfu, name='admin_assign_any_nonsfu'),
 
     url(r'^admin/completed/$', onlineforms_views.admin_completed, name='admin_completed'),
+    url(r'^admin/completed_deleted/$', onlineforms_views.admin_completed_deleted, name='admin_completed_deleted'),
     url(r'^admin/completed/' + FORM_SLUG + '/$', onlineforms_views.admin_completed_form, name='admin_completed_form'),
     url(r'^admin/rejected/' + FORM_SLUG + '/$', onlineforms_views.admin_rejected_form, name='admin_rejected_form'),
     url(r'^admin/completed/' + FORM_SLUG + '/summary$', onlineforms_views.summary_csv, name='summary_csv'),

--- a/onlineforms/views.py
+++ b/onlineforms/views.py
@@ -468,9 +468,15 @@ def _userToFormFiller(user):
 
 @requires_formgroup()
 def admin_completed(request):
-    forms = Form.objects.filter(owner__in=request.formgroups).order_by('unit__slug', 'title').select_related('unit')
+    forms = Form.objects.filter(owner__in=request.formgroups, active=True).order_by('unit__slug', 'title').select_related('unit')
     context = {'forms': forms}
     return render(request, "onlineforms/admin/admin_completed.html", context)
+
+@requires_formgroup()
+def admin_completed_deleted(request):
+    forms = Form.objects.filter(owner__in=request.formgroups, active=False).order_by('unit__slug', 'title').select_related('unit')
+    context = {'forms': forms}
+    return render(request, "onlineforms/admin/admin_completed_deleted.html", context)
 
 @requires_formgroup()
 def admin_completed_form(request, form_slug):

--- a/tacontracts/models.py
+++ b/tacontracts/models.py
@@ -294,7 +294,7 @@ class TAContract(models.Model):
     accepted_by_student = models.BooleanField(default=False, 
                   help_text="Has the student accepted the contract?")
 
-    comments = models.TextField(blank=True)
+    comments = models.TextField(max_length=625, blank=True)
     # curtis-lassam-2014-09-01 
     def autoslug(self):
         return make_slug(self.person.first_name + '-' + self.person.last_name \

--- a/templates/onlineforms/admin/admin_completed.html
+++ b/templates/onlineforms/admin/admin_completed.html
@@ -10,6 +10,15 @@
     <li>Completed</li>
 {% endblock %}
 
+{% block actions %}
+<div id="actions">
+    <h2 class="heading">Actions</h2>
+    <ul>
+        <li><a href="{% url "onlineforms:admin_completed_deleted" %}">Deleted Form Submissions</a></li>
+    </ul>
+</div>
+{% endblock %}
+
 {% block content %}
 <p>You have access to submissions for these forms:</p>
 <ul>

--- a/templates/onlineforms/admin/admin_completed_deleted.html
+++ b/templates/onlineforms/admin/admin_completed_deleted.html
@@ -1,0 +1,21 @@
+{% extends "base.html" %}
+{% load form_display %}
+
+{% block title %}Deleted Form Submissions{% endblock %}
+{% block h1 %}Deleted Form Submissions{% endblock %}
+
+{% block subbreadcrumbs %}
+    <li><a href="{% url "onlineforms:index" %}">Forms</a></li>
+    <li><a href="{% url "onlineforms:admin_list_all" %}">Admin Forms</a></li>
+    <li><a href="{% url "onlineforms:admin_completed" %}">Completed Forms</a></li>
+    <li>Deleted Forms</li>
+{% endblock %}
+
+{% block content %}
+<p>You have access to submissions for these deleted forms:</p>
+<ul>
+    {% for f in forms %}
+    <li><a href="{% url 'onlineforms:admin_completed_form' form_slug=f.slug %}">{{ f.title }} [{{ f.unit.label }}]</a></li>
+    {% endfor %}
+</ul>
+{% endblock %}

--- a/templates/onlineforms/admin/admin_completed_deleted.html
+++ b/templates/onlineforms/admin/admin_completed_deleted.html
@@ -7,8 +7,8 @@
 {% block subbreadcrumbs %}
     <li><a href="{% url "onlineforms:index" %}">Forms</a></li>
     <li><a href="{% url "onlineforms:admin_list_all" %}">Admin Forms</a></li>
-    <li><a href="{% url "onlineforms:admin_completed" %}">Completed Forms</a></li>
-    <li>Deleted Forms</li>
+    <li><a href="{% url "onlineforms:admin_completed" %}">Completed</a></li>
+    <li>Deleted</li>
 {% endblock %}
 
 {% block content %}

--- a/templates/visas/view_visa.html
+++ b/templates/visas/view_visa.html
@@ -21,6 +21,7 @@
 
 {% block content %}
     <dt>Person</dt><dd>{{ visa.person }}</dd>
+    <dt>ID</dt><dd>{{ visa.person.emplid }}</dd>
     <dt>Unit</dt><dd>{{ visa.unit.name }}</dd>
     <dt>Status</dt><dd>{{ visa.get_status_display }}</dd>
     <dt>Start Date</dt><dd>{{ visa.start_date }}</dd>

--- a/templates/visas/view_visas.html
+++ b/templates/visas/view_visas.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "base-wide.html" %}
 {% load static %}
 {% load visa_display %}
 
@@ -14,34 +14,30 @@
 <link rel="stylesheet" href="{% static "style/tacontracts.css" %}" type="text/css">
 <script nonce="{{ CSP_NONCE }}">
 $(document).ready(function() {
-  $('#visas').dataTable( {
+    $('#visas').dataTable( {
     'bPaginate': false,
     'bInfo': false,
     'bLengthChange': false,
     "bJQueryUI": true,
-    'aaSorting': [[2, 'asc']]
+    'aaSorting': [[3, 'asc']]
   } );
 } );
 </script>
 {% endblock %}
 
-{% block actions %}
-<div id="actions">
-    <h2>Actions</h2>
-    <ul>
-        <li><a href="{% url "visas:new_visa" %}">Add New Visa</a></li>
-        <li><a href="{% url 'visas:download_visas_csv' %}">Download CSV</a></li>
-    </ul>
-</div>
-{% endblock %}
-
 {% block content %}
+
+<p>
+    <a href="{% url "visas:new_visa" %}">Add New Visa</a>
+    | <a href="{% url 'visas:download_visas_csv' %}">Download CSV</a>
+</p>
 
 {% if visa_list %}
     <table id="visas" class="display">
         <thead>
             <tr>
                 <th>Person</th>
+                <th>ID</th>
                 <th>Unit</th>
                 <th>Start Date</th>
                 <th>End Date</th>
@@ -57,6 +53,7 @@ $(document).ready(function() {
                         {{ visa.person }} {% if visa.has_attachments %} &nbsp;
                         <i class="fa fa-paperclip" title="Attachment(s)"></i>{% endif %}
                     </td>
+                    <td>{{ visa.person.emplid }}</td>
                     <td>{{ visa.unit.label }}</td>
                     <td><span class="sort">{{ visa.start_date.isoformat }}</span>{{ visa.start_date }}</td>
                     <td><span class="sort">{{ visa.end_date.isoformat }}</span>{{ visa.end_date }}</td>


### PR DESCRIPTION
**Visa Display - Add ID**
- Added ID as a column to Visa table so we can search for it (some people have very similar names and being more specific will be useful).
- Switched table to wide-view because adding the extra column made the table rows expand height-wise with the longest of names.
![image](https://user-images.githubusercontent.com/17059664/109244005-c80a9780-7792-11eb-8f12-595601b368fa.png)

**Online Forms Completed Submissions**
- Separate out completed submissions by active and inactive. I added a new page for those who may want to see completed submissions from deleted forms (although unlikely). There were lots of forms on the completed submissions page that had the same names because of people deleting and restarting forms, so it was getting messy.
![image](https://user-images.githubusercontent.com/17059664/109243977-bc1ed580-7792-11eb-8ec7-40331dfb1fbf.png)

**TA Offer Letter Remarks Section**
- Added a max length of 650 characters to comments since if comments were too long, they would just not show up on the pdf, causing problems. This validation will ensure that never happens.
- Added a bit more space for comments on TA offer letters (moved section up a few mm and reduced font size) so that some letters that were experiencing this issue now work.

**Online Forms Completed Forms Export**
- For summaries of submissions, sheets and fields were included that were no longer active. This apparently isn't super useful and they just want a summary of anything active. For specific submissions they can still look back on deleted sections.
- I just ensured that when exporting, we include active sheets and fields only.
