### PR TITLE
To fix the missing solid icons on grad student module.

### DIFF
--- a/media/style/main.css
+++ b/media/style/main.css
@@ -202,7 +202,7 @@ div.breadcrumb ul li:first-child:before {
 .collapsible-heading:before {
   font-family: "Font Awesome 5 Free";
   font-style: normal;
-  font-weight: normal;
+  font-weight: 900;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   padding-right: 0.25em;
@@ -211,7 +211,7 @@ div.breadcrumb ul li:first-child:before {
 .collapsible-heading-collapsed:before {
   font-family: "Font Awesome 5 Free";
   font-style: normal;
-  font-weight: normal;
+  font-weight: 900;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   padding-right: 0.25em;


### PR DESCRIPTION
Reason: New version of font awesome library required font-weight: 900 to display solid icons.
(Reference: https://github.com/FortAwesome/Font-Awesome/issues/11946)

Before: 
![image](https://user-images.githubusercontent.com/82476895/117484467-f4bdf680-af1b-11eb-85c8-5c38cd3172f0.png)

After:
![image](https://user-images.githubusercontent.com/82476895/117484492-fa1b4100-af1b-11eb-9771-bc439c860684.png)
