### PR TITLE
Update access to RA Requests and add 'Select All' to admin role renewals

### DIFF
--- a/coredata/models.py
+++ b/coredata/models.py
@@ -75,7 +75,7 @@ ROLE_CHOICES = (
 ROLES = dict(ROLE_CHOICES)
 # roles departmental admins ('ADMN') are allowed to assign within their unit
 UNIT_ROLES = ['ADVS', 'ADVM', 'DISC', 'DICC', 'TAAD', 'GRAD', 'FUND', 'FDRE', 'FDCC', 'GRPD',
-              'FAC', 'SESS', 'COOP', 'INST', 'SUPV', 'OUTR', 'INV', 'FACR', 'FACA', 'RELA', 'SPAC', 'FORM']
+              'SESS', 'COOP', 'INST', 'SUPV', 'OUTR', 'INV', 'FACR', 'FACA', 'RELA', 'SPAC', 'FORM']
 # roles that give access to SIMS data
 SIMS_ROLES = ['ADVS', 'ADMV', 'DISC', 'DICC', 'FUND', 'GRAD', 'GRPD']
 

--- a/coredata/views.py
+++ b/coredata/views.py
@@ -1055,7 +1055,7 @@ EXCLUDE_EMPLIDS = set(['953022983']) # exclude these from autocomplete
 def student_search(request):
     # check permissions
     roles = Role.all_roles(request.user.username)
-    allowed = set(['ADVS', 'ADMN', 'GRAD', 'FUND', 'SYSA', 'FACA', 'FAC'])
+    allowed = set(['ADVS', 'ADMN', 'GRAD', 'FUND', 'SYSA', 'FACA', 'FDRE'])
     if not(roles & allowed) and not has_formgroup(request) and not has_global_role('DISC', request):
         # doesn't have any allowed roles
         return ForbiddenResponse(request, "Not permitted to do student search.")

--- a/privacy/models.py
+++ b/privacy/models.py
@@ -9,7 +9,7 @@ PRIVACY_VERSION = 1
 PRIVACY_DA_VERSION = 1
 
 # Who has to sign the Privacy statement?
-RELEVANT_ROLES = ['ADVS', 'ADMN', 'TAAD', 'GRAD', 'GRPD', 'FUND', 'FAC', 'FDRE']
+RELEVANT_ROLES = ['ADVS', 'ADMN', 'TAAD', 'GRAD', 'GRPD', 'FUND', 'FDRE']
 
 
 def set_privacy_signed(person):

--- a/ra/models.py
+++ b/ra/models.py
@@ -220,13 +220,15 @@ DEFAULT_LETTER_RA = '\n\n'.join([
 
 DEFAULT_LETTER_NCBW_VACATION = "Vacation time: This offer includes %(weeks_vacation)s weeks of vacation per calendar year, which will be __ days prorated for the duration of your appointment.\n\n"
 
+DEFAULT_LETTER_NC_EMPLOYMENT_STANDARDS = "Employment Standards Act: Any terms and conditions of employment which have not been expressly addressed in this letter but which are covered by the ESA, will be dealt with in conformity with the relevant provisions of the ESA, linked <a href='https://www.bclaws.gov.bc.ca/civix/document/id/complete/statreg/00_96113_01'> here.</a>\n\n"
+
 DEFAULT_LETTER_TRAINING = "Mandatory SFU Safety Orientation Training: WorkSafe BC requires all new employees to take complete safety orientation training.  SFU has a short online module you can take here: https://canvas.sfu.ca/enroll/RR8WDW, and periodically offers classroom sessions of the same material.  You shall be informed if any additional training is required.\n\n"
 
 DEFAULT_LETTER_CONCLUDE = "If you accept the terms of this letter, please sign and return the letter, retaining the original for your records.\n\n"
 DEFAULT_LETTER_CONCLUDE_NC = "If you accept the terms of this appointment, please sign and return the letter, retaining the original for your records.\n\n"
 
-DEFAULT_LETTER_NCH = DEFAULT_LETTER_NCH_INTRO + DEFAULT_LETTER_NC + DEFAULT_LETTER_TRAINING + DEFAULT_LETTER_CONCLUDE_NC
-DEFAULT_LETTER_NCBW = DEFAULT_LETTER_NCBW_INTRO + DEFAULT_LETTER_NC + DEFAULT_LETTER_NCBW_VACATION + DEFAULT_LETTER_TRAINING + DEFAULT_LETTER_CONCLUDE_NC
+DEFAULT_LETTER_NCH = DEFAULT_LETTER_NCH_INTRO + DEFAULT_LETTER_NC + DEFAULT_LETTER_NC_EMPLOYMENT_STANDARDS + DEFAULT_LETTER_TRAINING + DEFAULT_LETTER_CONCLUDE_NC
+DEFAULT_LETTER_NCBW = DEFAULT_LETTER_NCBW_INTRO + DEFAULT_LETTER_NC + DEFAULT_LETTER_NCBW_VACATION + DEFAULT_LETTER_NC_EMPLOYMENT_STANDARDS + DEFAULT_LETTER_TRAINING + DEFAULT_LETTER_CONCLUDE_NC
 DEFAULT_LETTER_RAH = DEFAULT_LETTER_RAH_INTRO + DEFAULT_LETTER_RA + DEFAULT_LETTER_TRAINING + DEFAULT_LETTER_CONCLUDE
 DEFAULT_LETTER_RABW = DEFAULT_LETTER_RABW_INTRO + DEFAULT_LETTER_RA + DEFAULT_LETTER_TRAINING + DEFAULT_LETTER_CONCLUDE
 DEFAULT_LETTER_GRASLS_OUTSIDE_CAN = DEFAULT_LETTER_GRASLS_INTRO_OUTSIDE_CAN + DEFAULT_LETTER_GRAS + DEFAULT_LETTER_TRAINING + DEFAULT_LETTER_CONCLUDE

--- a/templates/coredata/renew_unit_roles.html
+++ b/templates/coredata/renew_unit_roles.html
@@ -18,6 +18,9 @@ $(document).ready(function() {
     "bJQueryUI": true,
     'aaSorting': [[1, 'asc']],
   } );
+  $("#selectAll").change(function() {
+        $(".checkMe:checkbox").prop('checked', this.checked);
+  } );
 } );
 </script>
 {% endblock %}
@@ -27,7 +30,7 @@ $(document).ready(function() {
 {% csrf_token %}
 <div class="datatable_container">
   <table id="roles" class="display">
-    <thead><tr><th scope="col">Name</th><th scope="col">Role</th><th scope="col">Expires</th><th scope="col">Unit</th><th scope="col">Renew</th></tr></thead>
+    <thead><tr><th scope="col">Name</th><th scope="col">Role</th><th scope="col">Expires</th><th scope="col">Unit</th><th scope="col">Renew {% if roles %}<input type="checkbox" id="selectAll"/>{% endif %}</th></tr></thead>
     <tbody>
     <strong>The following roles are eligible for renewal:</strong>
     {% for role in roles %}
@@ -37,7 +40,7 @@ $(document).ready(function() {
     <td>{{role.expiry.isoformat}}</td>
     <td>{{role.unit}}</td>
     <td>
-      <input type="checkbox" name="renewals" value="{{role.id}}">
+      <input type="checkbox" class="checkMe" name="renewals" value="{{role.id}}">
     </td></tr>
     {% endfor %}
     </tbody>

--- a/templates/dashboard/index.html
+++ b/templates/dashboard/index.html
@@ -52,7 +52,7 @@ $(document).ready(function() {
     {% endif %}
     
     {% if has_grads %}<li><a href="{% url "dashboard:supervisor_index" %}"><i class="fa fa-li fa-group"></i> My Grad Students</a></li>{% endif %}
-    {% if has_ra_requests or has_ras or 'FAC' in roles %}<li><a href="{% url "ra:browse_appointments" %}"><i class="fa fa-li fa-user-plus"></i> My RA Dashboard</a></li>{% endif %}
+    {% if has_ra_requests or has_ras or 'FDRE' in roles %}<li><a href="{% url "ra:browse_appointments" %}"><i class="fa fa-li fa-user-plus"></i> My RA Dashboard</a></li>{% endif %}
 
     {% if 'SYSA' in roles %}
     <li><a href="{% url "sysadmin:sysadmin" %}"><i class="fa fa-li fa-bolt"></i> System Administration</a></li>{% endif %}

--- a/templates/ra/new_request/intro.html
+++ b/templates/ra/new_request/intro.html
@@ -82,7 +82,7 @@
       <td><u>{{ cs_contact }}</u></td>
       </tr><tr> 
       <td>MSE</td>
-      <td>Confidential Assistant to the Director</td>
+      <td>Administrative Assistant</td>
       <td><u>{{  mse_contact }}</u></td>
       </tr><tr>
       <td>ENSC</td>


### PR DESCRIPTION
Separating the Faculty Member role from any access to the RA Module:

- Removed 'Faculty Member' as a role that Departmental Admins are allowed to assign within their units. (Should instead be assigned here: https://coursys.sfu.ca/faculty/members).
- Replaced 'Faculty Member' with 'Grad Funding Requester' for access to RA Requests.
- 'Faculty Members' no longer have to sign privacy agreements (they now do not have access to anything that requires one) and can no longer search for students in autocompleted Person fields.
- 'Grad Funding Requesters' now must sign the privacy agreement (if they have not already), and can search for students in autocompleted Person fields.

Added 'FDRE: Grad Funding Requester' previously here: https://github.com/sfu-fas/coursys/pull/179

- Also added a checkbox to 'Select All' for admin renewing roles.


