### PR TITLE
fix stock status issues in inventory

### DIFF
--- a/inventory/forms.py
+++ b/inventory/forms.py
@@ -20,7 +20,7 @@ class AssetForm(forms.ModelForm):
         self.fields['category'].choices = SORTED_CATEGORIES
 
     class Meta:
-        exclude = []
+        exclude = ['stock_status']
         model = Asset
         widgets = {
             'notes': forms.Textarea,

--- a/inventory/models.py
+++ b/inventory/models.py
@@ -28,6 +28,7 @@ CATEGORY_CHOICES = {
     ('ADMN', 'Admin Support'),
     ('TECH', 'Tech Support'),
     ('ELEC', 'Electronics'),
+    ('PPE', 'PPE')
 }
 
 STOCK_STATUS_CHOICES = {

--- a/media/js/inventory.js
+++ b/media/js/inventory.js
@@ -40,7 +40,10 @@ function hide_fields(fields) {
     }
     for (var i = 0; i < fields.length; i++)
     {
-
+        // ensure min_qty is set to 0 if hidden, so stock status still works
+        if (fields[i] == 'min_qty') { 
+            $('#id_min_qty').val(0);
+        }
         var real_id = 'id_' + fields[i];
         var label = $("label[for=" + real_id + "]");
         label.parent().hide();

--- a/media/style/inventory.css
+++ b/media/style/inventory.css
@@ -12,6 +12,7 @@
 
 #filterform li span.field label {
     margin-left: 0.5em;
+    white-space: nowrap;
 }
 
 .filter {


### PR DESCRIPTION
* stock status is determined by minimum re-order quantity and quantity fields, so shouldn't be a visible field on the form
* stock status is getting stuck, or is always 'unknown', when the category/unit is updated to one where minimum reorder quantity is hidden