### PR TITLE
TA enhancement for 1231

### DIFF
--- a/templates/ta/_ta_application.html
+++ b/templates/ta/_ta_application.html
@@ -15,6 +15,7 @@
       <a href="{% url "grad:view" grad_slug=g.slug %}">{{g}} - {{g.get_current_status_display}}</a>
       {% endfor %}
     </td></tr>
+    <tr><th scope="row">Other program comments</th><td>{{ application.program_comment }}</td></tr>
     <tr><th scope="row">Experience</th><td>{{ application.experience|linebreaksbr }}</td></tr>
     <tr><th scope="row">Course Load</th><td>{{ application.course_load|linebreaksbr }}</td></tr>
     <tr><th scope="row">Other Support</th><td>{{ application.other_support|linebreaksbr }}</td></tr>

--- a/templates/ta/assign_tas.html
+++ b/templates/ta/assign_tas.html
@@ -79,7 +79,7 @@
 <tr>
   <td scope="row" title="{{o.title}}">
     {% if o.component == "CAN" %}<del>{% endif %}
-    <a href="{% url "ta:assign_bus" post_slug=posting.slug course_slug=o.slug %}">{{o.name}} x{{ o.combinedoffering.name }}</a>
+    <a href="{% url "ta:assign_bus" post_slug=posting.slug course_slug=o.slug %}">{{o.name}}</a>
     {% if o.component == "CAN" %}</del>{% endif %}
     </td>
   <td>{% for instructor in o.instructors %}<a href="mailto:{{ instructor.email }}">{{ instructor.sortname }}</a>{% if not forloop.last %}, {% endif %}{% endfor %}</td>

--- a/templates/ta/assign_tas.html
+++ b/templates/ta/assign_tas.html
@@ -68,16 +68,18 @@
     <th scope="col">Campus</th>
 	<th scope="col">Assigned</th>
 	<th scope="col">Applicants</th>
-	<th scope="col">Required BU</th>
+  <th scope="col">Required BU (by capacity)</th>
+	<th scope="col">Required BU (by enrol.)</th>
     <th scope="col">Assigned BU</th>
     <th scope="col">Diff</th>
-    <th scope="col">Required @Cap</th></tr></thead>
+  </tr>
+ </thead>
 <tbody>
 {% for o in offerings %}
 <tr>
   <td scope="row" title="{{o.title}}">
     {% if o.component == "CAN" %}<del>{% endif %}
-    <a href="{% url "ta:assign_bus" post_slug=posting.slug course_slug=o.slug %}">{{o.name}}</a>
+    <a href="{% url "ta:assign_bus" post_slug=posting.slug course_slug=o.slug %}">{{o.name}} x{{ o.combinedoffering.name }}</a>
     {% if o.component == "CAN" %}</del>{% endif %}
     </td>
   <td>{% for instructor in o.instructors %}<a href="mailto:{{ instructor.email }}">{{ instructor.sortname }}</a>{% if not forloop.last %}, {% endif %}{% endfor %}</td>
@@ -85,13 +87,14 @@
   <td>{{o.get_campus_display}}</td>
   <td>
   	{% for tacrs in o.assigned %}
-    {% if tacrs.bu > 0 %}
+    {% if tacrs.total_bu > 0 %}
   	    <a href="mailto:{{tacrs.contract.application.person.email}}">{{tacrs.contract.application.person.sortname}}</a>
-  	    ({{tacrs.bu}}){% if not forloop.last %}, {% endif %}
+  	    ({{tacrs.total_bu }}){% if not forloop.last %}, {% endif %}
     {% endif %}
   	{% endfor %}
   </td>
   <td class="num">{{ o|display_applicant_count:posting }}</td>
+  <td class="num">{{ o|display_bu_cap:posting }}</td>
   <td class="num">{{ o|display_required_bu:posting }}
     {% if o|display_extra_bu:posting != "0.00" %} 
         <br/>({{ o|display_default_bu:posting }}+{{o|display_extra_bu:posting}}) 
@@ -99,7 +102,6 @@
   </td>
   <td class="num">{{ o|display_assigned_bu:posting }}</td>
   <td class="num">{{ o|display_bu_difference:posting }}</td>
-  <td class="num">{{ o|display_bu_cap:posting }}</td>
 </tr>	
 {% endfor %}
 </tbody>

--- a/templates/ta/edit_contract.html
+++ b/templates/ta/edit_contract.html
@@ -143,6 +143,10 @@
                     function(data){
                         var val = parseFloat(data)
                         $(bu_inp).val(val.toFixed(2))
+						// default desc_sel
+						if ($(desc_sel).val() == 0)
+							$(desc_sel).val($('select[class="desc_select"] > option:contains("Office/Marking/Lab (+0.17 BU)")').val())
+   						
                     });
 			}
 			else{

--- a/templates/ta/view_all_applications.html
+++ b/templates/ta/view_all_applications.html
@@ -31,6 +31,7 @@
     <th scope="col">ID</th>
 	<th scope="col">Category</th>
     <th scope="col">Program</th>
+    <th scope="col">Other Program Comment</th>
 	<th scope="col">Assigned BUs</th>
 	<th scope="col">Max BUs</th>
 	<th scope="col">Ranked</th>
@@ -47,6 +48,7 @@
     <td>{{ app.person.emplid }}</td>
   	<td>{{ app.get_category_display }}</td>
     <td>{{ app.get_current_program_display }}</td>
+    <td>{{ app.program_comment }} </td>
   	<td>{{ app.base_units_assigned }}</td>
   	<td>{{ app.base_units }}</td>
   	<td>{{ app.course_pref_display }}</td>


### PR DESCRIPTION
1)  TA contracts – always default course description as “Office/Marking/Lab (+0.17BU)” on the detail when creating a contract

2)  Assign TAs –
a.  update the BU formula
i.      Required BU: [Enrollment * 0.08 + 1.17]
ii.      Required @Cap Cap: [Capacity * 0.08 + 1.17]
iii.      Writing course: plus 2 for required BU and @Cap
b.  Move the Required@Cap column a bit front (maybe after applicants column), and move Required BU/Assign BU/Diff near the end of row
c.  Update label “Required BU” to “Required BU (by enroll.)”, and “Required@Cap” to “Required BU (by capacity)”, or any more meaningful label
d.  fix a bug - display student's total BU didn't include 0.17

3) Add columns to spreadsheet CSV
i.      On Assign TA – Applicant Spreadsheet, add SFUID and SFU email address
ii.      On view all TA application – Download CSV, add SFU email address

4) Apply – Add text box to allow student to input if they choose ‘Other program’ in department. The new text box has to add to corresponding CSV as well

**Please run "python manage.py makemigrations ta -n add_program_comment" and "python manage.py migrate ta" for item 4**