### PR TITLE
Discussion Forum preserves pseudonyms (#273)

### DIFF
--- a/forum/models.py
+++ b/forum/models.py
@@ -188,7 +188,7 @@ class Identity(models.Model):
         return member.person.name_pref()
 
     @staticmethod
-    def identity_choices(offering_identity, member):
+    def identity_choices(offering_identity: str, member: Member):
         """
         Allowed identity.choices for an offering with this identity restrictions.
         """
@@ -197,6 +197,7 @@ class Identity(models.Model):
         choices = [
             ('NAME', 'Post with your real name (as “%s”)' % (real_name,))
         ]
+        # ANON has an extra option compared to INST.
         if member.role == 'STUD' and offering_identity == 'ANON':
             choices.append(('ANON', 'Anonymously (as “%s”)' % (anon_name,)))
         if member.role == 'STUD' and offering_identity in ['ANON', 'INST']:

--- a/forum/views.py
+++ b/forum/views.py
@@ -346,7 +346,8 @@ def edit_post(request: ForumHttpRequest, post_number: int) -> HttpResponse:
         raise Http404()
 
     if request.method == 'POST':
-        form = Form(instance=post, data=request.POST, member=request.member, offering_identity=request.forum.identity)
+        form = Form(instance=post, data=request.POST, member=request.member, offering_identity=request.forum.identity,
+                    initial_identity=post.identity)
         if form.is_valid():
             post = form.save(commit=False)
             post.offering = request.offering
@@ -368,9 +369,10 @@ def edit_post(request: ForumHttpRequest, post_number: int) -> HttpResponse:
     else:
         if thread:
             form = Form(instance=post, offering_identity=request.forum.identity, member=request.member,
-                                     initial={'title': thread.title, 'privacy': thread.privacy})
+                        initial_identity=post.identity, initial={'title': thread.title, 'privacy': thread.privacy})
         else:
-            form = Form(instance=post, offering_identity=request.forum.identity, member=request.member)
+            form = Form(instance=post, offering_identity=request.forum.identity, member=request.member,
+                        initial_identity=post.identity)
 
     context = {
         'view': 'edit_post',


### PR DESCRIPTION
Discussion Forum preserves pseudonyms on the edit page.

Resolve #273.