### PR TITLE
more-correct handling of non-printing instructors from SIMS

### DIFF
--- a/coredata/importer.py
+++ b/coredata/importer.py
@@ -456,8 +456,11 @@ def ensure_member(person, offering, role, cred, added_reason, career, labtut_sec
         m.official_grade = None
 
     # record sched_print_instr status for instructors
-    if role=='INST' and sched_print_instr:
-        m.config['sched_print_instr'] = sched_print_instr == 'Y'
+    # if role=='INST' and sched_print_instr:
+    #     m.config['sched_print_instr'] = sched_print_instr == 'Y'
+    if role=='INST' and not sched_print_instr:
+        # convert non-printing instructors to grade approvers in our parlance
+        m.role = 'APPR'
 
     # if offering is being given lab/tutorial sections, flag it as having them
     # there must be some way to detect this in ps_class_tbl, but I can't see it.


### PR DESCRIPTION
Instructors who are "primary instructors" but "non-printing" in SIMS seem to be effectively "not actually instructors". There had been a special case in the course browser so they wouldn't display there, but I see no reason that shouldn't be applied globally (and a few were added in CMPT that were actually affecting me).
