### PR TITLE
Fixed browse page default to current semester - a real fix

### DIFF
--- a/coredata/urls.py
+++ b/coredata/urls.py
@@ -89,11 +89,11 @@ sysadmin_patterns = [ # prefix /sysadmin/
 
 browse_patterns = [ # prefix /browse/
     url(r'^$', coredata_views.browse_courses, name='browse_courses'),
-    url(r'^' + UNIT_SLUG + '$', coredata_views.browse_courses, name='browse_courses'),
-    url(r'^' + UNIT_SLUG + '/(?P<campus>[a-zA-Z]{1,9})$', coredata_views.browse_courses, name='browse_courses'),
     url(r'^info/' + COURSE_SLUG + '$', coredata_views.browse_courses_info, name='browse_courses_info'),
     url(r'^pages/$', coredata_views.course_home_pages, name='course_home_pages'),
-    url(r'^pages/' + UNIT_SLUG + '/$', coredata_views.course_home_pages_unit, name='course_home_pages_unit'),
+    url(r'^pages/' + UNIT_SLUG + '$', coredata_views.course_home_pages_unit, name='course_home_pages_unit'),
     url(r'^pages/' + UNIT_SLUG + '/' + SEMESTER + '$', coredata_views.course_home_pages_unit, name='course_home_pages_unit'),
     url(r'^pages/admin/' + COURSE_SLUG + '$', coredata_views.course_home_admin, name='course_home_admin'),
+    url(r'^' + UNIT_SLUG + '$', coredata_views.browse_courses, name='browse_courses'),
+    url(r'^' + UNIT_SLUG + '/(?P<campus>[a-zA-Z]{1,9})$', coredata_views.browse_courses, name='browse_courses'),    
 ]


### PR DESCRIPTION
Fixed browse page default to current semester - a real fix
1) Rollback previous change #386
2) Move the sequence of the patterns to match the pages/unit first.