### PR TITLE
Fixed browse page default to current semester - A real fix

### DIFF
--- a/coredata/urls.py
+++ b/coredata/urls.py
@@ -89,11 +89,11 @@ sysadmin_patterns = [ # prefix /sysadmin/
 
 browse_patterns = [ # prefix /browse/
     url(r'^$', coredata_views.browse_courses, name='browse_courses'),
-    url(r'^' + UNIT_SLUG + '$', coredata_views.browse_courses, name='browse_courses'),
-    url(r'^' + UNIT_SLUG + '/(?P<campus>[a-zA-Z]{1,9})$', coredata_views.browse_courses, name='browse_courses'),
     url(r'^info/' + COURSE_SLUG + '$', coredata_views.browse_courses_info, name='browse_courses_info'),
     url(r'^pages/$', coredata_views.course_home_pages, name='course_home_pages'),
-    url(r'^pages/' + UNIT_SLUG + '/$', coredata_views.course_home_pages_unit, name='course_home_pages_unit'),
+    url(r'^pages/' + UNIT_SLUG + '$', coredata_views.course_home_pages_unit, name='course_home_pages_unit'),
     url(r'^pages/' + UNIT_SLUG + '/' + SEMESTER + '$', coredata_views.course_home_pages_unit, name='course_home_pages_unit'),
     url(r'^pages/admin/' + COURSE_SLUG + '$', coredata_views.course_home_admin, name='course_home_admin'),
+    url(r'^' + UNIT_SLUG + '$', coredata_views.browse_courses, name='browse_courses'),
+    url(r'^' + UNIT_SLUG + '/(?P<campus>[a-zA-Z]{1,9})$', coredata_views.browse_courses, name='browse_courses'),    
 ]

--- a/coredata/urls.py
+++ b/coredata/urls.py
@@ -94,7 +94,7 @@ browse_patterns = [ # prefix /browse/
     url(r'^pages/' + UNIT_SLUG + '$', coredata_views.course_home_pages_unit, name='course_home_pages_unit'),
     url(r'^pages/' + UNIT_SLUG + '/' + SEMESTER + '$', coredata_views.course_home_pages_unit, name='course_home_pages_unit'),
     url(r'^pages/admin/' + COURSE_SLUG + '$', coredata_views.course_home_admin, name='course_home_admin'),
-    url(r'^pages/' + UNIT_SLUG + '/', coredata_views.course_home_pages_unit, name='course_home_pages_unit'),          
+    url(r'^pages/' + UNIT_SLUG + '/$', coredata_views.course_home_pages_unit, name='course_home_pages_unit'),          
     url(r'^' + UNIT_SLUG + '$', coredata_views.browse_courses, name='browse_courses'),
     url(r'^' + UNIT_SLUG + '/(?P<campus>[a-zA-Z]{1,9})$', coredata_views.browse_courses, name='browse_courses'),    
 ]

--- a/coredata/urls.py
+++ b/coredata/urls.py
@@ -94,6 +94,7 @@ browse_patterns = [ # prefix /browse/
     url(r'^pages/' + UNIT_SLUG + '$', coredata_views.course_home_pages_unit, name='course_home_pages_unit'),
     url(r'^pages/' + UNIT_SLUG + '/' + SEMESTER + '$', coredata_views.course_home_pages_unit, name='course_home_pages_unit'),
     url(r'^pages/admin/' + COURSE_SLUG + '$', coredata_views.course_home_admin, name='course_home_admin'),
+    url(r'^pages/' + UNIT_SLUG + '/', coredata_views.course_home_pages_unit, name='course_home_pages_unit'),          
     url(r'^' + UNIT_SLUG + '$', coredata_views.browse_courses, name='browse_courses'),
     url(r'^' + UNIT_SLUG + '/(?P<campus>[a-zA-Z]{1,9})$', coredata_views.browse_courses, name='browse_courses'),    
 ]


### PR DESCRIPTION
1) Rollback previous change (we have many webpages contain URLs with slash or without slash pattern (eg. browse/pages/cmpt/ and browse/pages/cmpt ), so better allow both
2) Move two URLs down below avoid being matched to early
