### PR TITLE
updates to proddev setup notes; db dump tool for faster restores

### DIFF
--- a/docker-compose-proddev.yml
+++ b/docker-compose-proddev.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
 
   mysql:
-    image: 'mysql:5.7'
+    image: 'mariadb:11'
     restart: always
     command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
     ports:

--- a/instructions/DOCKER_PRODDEV.md
+++ b/instructions/DOCKER_PRODDEV.md
@@ -20,9 +20,9 @@ RABBITMQ_PASSWORD = 'rabbitmq_password'
 Get the Docker-based things up and running:
 ```sh
 export RABBITMQ_PASSWORD=rabbitmq_password
-docker-compose -f docker-compose.yml -f docker-compose-proddev.yml pull
-docker-compose -f docker-compose.yml -f docker-compose-proddev.yml build
-docker-compose -f docker-compose.yml -f docker-compose-proddev.yml up -d
+docker compose -f docker-compose.yml -f docker-compose-proddev.yml pull
+docker compose -f docker-compose.yml -f docker-compose-proddev.yml build --pull
+docker compose -f docker-compose.yml -f docker-compose-proddev.yml up -d
 ```
 
 Basic setup as necessary: activate a virtualenv and,
@@ -32,6 +32,8 @@ npm install
 python3 manage.py migrate
 python3 manage.py loaddata fixtures/*.json
 python3 manage.py update_index
+sudo mkdir -p /data/submitted_files
+sudo chown $USER /data/submitted_files
 ```
 
 In one terminal, start Celery:
@@ -47,6 +49,7 @@ python3 manage.py runserver
 ## Shutting Down
 
 ```shell
-docker-compose -f docker-compose.yml -f docker-compose-proddev.yml stop
-docker-compose -f docker-compose.yml -f docker-compose-proddev.yml rm
+docker compose -f docker-compose.yml -f docker-compose-proddev.yml stop
+docker compose -f docker-compose.yml -f docker-compose-proddev.yml rm
+# sudo rm -rf /data/*
 ```

--- a/ruby-markup/Dockerfile
+++ b/ruby-markup/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.0
+FROM ruby:3
 
 RUN bundle config --global frozen 1
 

--- a/ruby-markup/Gemfile
+++ b/ruby-markup/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
 
-gem 'commonmarker'
-gem 'github-markup'
+gem 'commonmarker', '0.23.10'
+gem 'github-markup', '4.0.2'
 gem 'bunny'

--- a/ruby-markup/Gemfile.lock
+++ b/ruby-markup/Gemfile.lock
@@ -1,25 +1,25 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    amq-protocol (2.3.2)
-    bunny (2.18.0)
-      amq-protocol (~> 2.3, >= 2.3.1)
+    amq-protocol (2.3.4)
+    bunny (2.24.0)
+      amq-protocol (~> 2.3)
       sorted_set (~> 1, >= 1.0.2)
     commonmarker (0.23.10)
-    github-markup (4.0.0)
-    rbtree (0.4.4)
-    set (1.0.1)
+    github-markup (4.0.2)
+    rbtree (0.4.6)
+    set (1.1.2)
     sorted_set (1.0.3)
       rbtree
       set (~> 1.0)
 
 PLATFORMS
-  x86_64-linux
+  x86_64-linux-gnu
 
 DEPENDENCIES
   bunny
-  commonmarker
-  github-markup
+  commonmarker (= 0.23.10)
+  github-markup (= 4.0.2)
 
 BUNDLED WITH
-   2.2.15
+   2.4.20

--- a/ruby-markup/README.md
+++ b/ruby-markup/README.md
@@ -15,6 +15,7 @@ minimal Ruby development environment. Something like this:
 ```shell
 sudo apt install ruby-bundler
 cd ruby-markup
+rm Gemfile.lock
 bundle install
 git add Gemfile.lock
 ```

--- a/tools/dbdump_split.py
+++ b/tools/dbdump_split.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+
+# Likely usage:
+# ./manage.py dbdump --filename - | ./tools/dbdump_split.py
+
+# Then to restore most of the database:
+# pv dbdump.sql | ./manage.py dbshell
+# System should now be in a working state. Then at your leisure, restore the request log:
+# pv requestlog.sql | ./manage.py dbshell
+
+
+import re
+import sys
+
+start_inserts = re.compile(r'^LOCK TABLES `log_requestlog` WRITE')
+end_inserts = re.compile(r'^UNLOCK TABLES')
+in_requestlog = False
+
+dump = open('dbdump.sql', 'w')
+logdump = open('requestlog.sql', 'w')
+
+
+for line in sys.stdin:
+    if start_inserts.match(line):
+        in_requestlog = True
+    elif in_requestlog and end_inserts.match(line):
+        in_requestlog = False
+    
+    # logic here implicitly drops the LOCK and UNLOCK lines around the log_requestlog table inserts
+
+    elif in_requestlog:
+        logdump.write(line)
+    else:
+        dump.write(line)
+    
+
+'''
+# Note for testing to drop all tables in a dev environment from https://stackoverflow.com/a/12917793
+
+DROP PROCEDURE IF EXISTS `drop_all_tables`;
+
+DELIMITER $$
+CREATE PROCEDURE `drop_all_tables`()
+BEGIN
+    DECLARE _done INT DEFAULT FALSE;
+    DECLARE _tableName VARCHAR(255);
+    DECLARE _cursor CURSOR FOR
+        SELECT table_name 
+        FROM information_schema.TABLES
+        WHERE table_schema = SCHEMA();
+    DECLARE CONTINUE HANDLER FOR NOT FOUND SET _done = TRUE;
+
+    SET FOREIGN_KEY_CHECKS = 0;
+
+    OPEN _cursor;
+
+    REPEAT FETCH _cursor INTO _tableName;
+
+    IF NOT _done THEN
+        SET @stmt_sql = CONCAT('DROP TABLE IF EXISTS `', _tableName, '`');
+        PREPARE stmt1 FROM @stmt_sql;
+        EXECUTE stmt1;
+        DEALLOCATE PREPARE stmt1;
+    END IF;
+
+    UNTIL _done END REPEAT;
+
+    CLOSE _cursor;
+    SET FOREIGN_KEY_CHECKS = 1;
+END$$
+
+DELIMITER ;
+
+call drop_all_tables(); 
+
+DROP PROCEDURE IF EXISTS `drop_all_tables`;
+
+SHOW TABLES;
+'''


### PR DESCRIPTION
The changes to the proddev setup instructions are a result of prepping for a new db server.

The dbdump_split.py tool is intended to break the requestlog table out of a database dump, so it can be restored after the system is reactivated.