### PR TITLE
ensure periodic tasks obey DO_IMPORTING_HERE if they have external effects

### DIFF
--- a/coredata/tasks.py
+++ b/coredata/tasks.py
@@ -86,7 +86,8 @@ def regular_backup():
 
 @task()
 def backup_database():
-    call_command('backup_db', clean_old=True)
+    if settings.DO_IMPORTING_HERE:
+        call_command('backup_db', clean_old=True)
 
 
 @task()

--- a/forum/tasks.py
+++ b/forum/tasks.py
@@ -133,6 +133,9 @@ def create_instr_idents() -> None:
 
 @task()
 def send_digests(immediate=False) -> None:
+    if not settings.DO_IMPORTING_HERE:
+        return
+    
     now = datetime.datetime.now()
     idents = _relevant_idents().filter(digest_frequency__isnull=False)
     for i in idents:

--- a/onlineforms/tasks.py
+++ b/onlineforms/tasks.py
@@ -1,10 +1,12 @@
 from courselib.celerytasks import task
-from celery.schedules import crontab
+from django.conf import settings
 from onlineforms.models import SheetSubmission
 
 
 @task()
 def waiting_forms_reminder():
+    if not settings.DO_IMPORTING_HERE:
+        return
     SheetSubmission.email_waiting_sheets()
 
 @task()

--- a/onlineforms/tasks.py
+++ b/onlineforms/tasks.py
@@ -11,4 +11,6 @@ def waiting_forms_reminder():
 
 @task()
 def reject_dormant_initial():
+    if not settings.DO_IMPORTING_HERE:
+        return
     SheetSubmission.reject_dormant_initial()

--- a/ra/tasks.py
+++ b/ra/tasks.py
@@ -1,9 +1,11 @@
 from courselib.celerytasks import task
-from celery.schedules import crontab
+from django.conf import settings
 from ra.models import RAAppointment, RARequest
 
 
 @task()
 def expiring_ras_reminder():
+    if not settings.DO_IMPORTING_HERE:
+        return
     RAAppointment.email_expiring_ras()
     RARequest.email_expiring_ras()

--- a/reminders/tasks.py
+++ b/reminders/tasks.py
@@ -1,10 +1,12 @@
 from courselib.celerytasks import task
-from celery.schedules import crontab
+from django.conf import settings
 from .models import Reminder, ReminderMessage
 
 
 @task()
 def daily_reminders():
+    if not settings.DO_IMPORTING_HERE:
+        return
     Reminder.create_all_reminder_messages()
     ReminderMessage.send_all()
     ReminderMessage.cleanup()

--- a/reports/tasks.py
+++ b/reports/tasks.py
@@ -1,10 +1,12 @@
 from courselib.celerytasks import task
-from celery.schedules import crontab
+from django.conf import settings
 from reports.models import Report, schedule_ping
 
 
 @task()
 def run_regular_reports():
+    if not settings.DO_IMPORTING_HERE:
+        return
     schedule_ping()
 
 

--- a/ta/tasks.py
+++ b/ta/tasks.py
@@ -6,6 +6,8 @@ import datetime
 
 @task()
 def check_and_execute_reminders():
+    if not settings.DO_IMPORTING_HERE:
+        return
     semester = Semester.current()
     
     # check every day - if it is Day 0, 7, 14, 28 of the semester

--- a/ta/tasks.py
+++ b/ta/tasks.py
@@ -1,5 +1,5 @@
 from courselib.celerytasks import task
-from celery.schedules import crontab
+from django.conf import settings
 from ta.models import TAEvaluation
 from coredata.models import Semester, SemesterWeek
 import datetime


### PR DESCRIPTION
The intention has always been that `settings.DO_IMPORTING_HERE` will be True in exactly one place. This matters when we are in the middle of migrating servers, and want to ensure everything is tidy.

This PR disables some periodic tasks that would otherwise fire