### PR TITLE
add some convenient management commands

### DIFF
--- a/coredata/management/commands/backup_db_task.py
+++ b/coredata/management/commands/backup_db_task.py
@@ -1,0 +1,13 @@
+import sys
+
+from django.core.management.base import BaseCommand
+from coredata.tasks import backup_database
+
+class Command(BaseCommand):
+    help = "Trigger database backup task (and wait for completion)."
+
+    def handle(self, *args, **options):
+        sys.stdout.write("Starting database backup task... ")
+        res = backup_database.delay()
+        res.get()
+        sys.stdout.write("Backup complete.\n")

--- a/coredata/management/commands/purge_cache.py
+++ b/coredata/management/commands/purge_cache.py
@@ -1,0 +1,10 @@
+from django.core.management.base import BaseCommand
+from django.core.cache import cache
+
+
+class Command(BaseCommand):
+    help = "Purge everything in the Django cache."
+
+    def handle(self, *args, **options):
+        cache.clear()
+        

--- a/coredata/management/commands/update_index_task.py
+++ b/coredata/management/commands/update_index_task.py
@@ -1,0 +1,12 @@
+from django.core.management.base import BaseCommand
+from coredata.tasks import our_update_index
+
+
+class Command(BaseCommand):
+    def add_arguments(self, parser):
+        parser.add_argument('--full-rebuild', action='store_true', default=False)
+    
+    def handle(self, *args, **options):
+        update_only = not options['full_rebuild']
+        our_update_index.delay(update_only=update_only)
+        print(f"Started our_update_index(update_only={update_only})")


### PR DESCRIPTION
This adds some django management commands to do occasional admin tasks that would previously have been triggered manually (or were just inaccessible without difficulty).

backup_db_task: now must be done in the celery "batch" queue since it's the only one with access to the directory with database backups

purge_cache: shouldn't be necessary, but remove everything from memcached

update_index_task: do a haystack/elasticsearch update, but as a background celery task.