### PR TITLE
Rework celery beat config

### DIFF
--- a/courses/celery_schedule.py
+++ b/courses/celery_schedule.py
@@ -8,33 +8,39 @@ def beat(task: str, schedule: int | crontab, *, queue: str = 'batch'):
     entry = {
         'task': task,
         'schedule': schedule,
-        'queue': queue,
         'options': { 'queue': queue, 'routing_key': queue },
     }
     return (task, entry)
+
+
+# Celerybeat has had consistent problems with a non-UTC timezone. Thus it has been told to schedule in
+# UTC, and all times here must be in UTC (i.e. Vancouver + 7 hours)
+def h(hour):
+    "Convert hour from Vancouver to UTC"
+    return (hour + 7) % 24
 
 
 CELERY_BEAT_SCHEDULE = dict([
     beat('coredata.tasks.beat_test', 300, queue='fast'),
     beat('coredata.tasks.backup_database', crontab(minute=0, hour='*/3'), queue='batch'),
     beat('coredata.tasks.csrpt_refresh_periodic', 7200, queue='sims'),
-    beat('coredata.tasks.daily_import', crontab(minute='30', hour='8'), queue='sims'),
-    beat('grad.tasks.grad_daily_import', crontab(minute='40', hour='8'), queue='sims'),
+    beat('coredata.tasks.daily_import', crontab(minute='30', hour=h(8)), queue='sims'),
+    beat('grad.tasks.grad_daily_import', crontab(minute='40', hour=h(8)), queue='sims'),
     beat('coredata.tasks.check_sims_connection', crontab(minute=0, hour='*/3'), queue='sims'),
-    beat('coredata.tasks.expire_sessions_conveniently', crontab(minute='0', hour='4')),
-    beat('coredata.tasks.haystack_rebuild', crontab(minute='0', hour='2', day_of_week='saturday'), queue='batch'),
-    beat('coredata.tasks.expiring_roles', crontab(minute='30', hour='7', day_of_week='mon,thu')),
-    beat('dashboard.tasks.photo_password_update_task', crontab(day_of_month="10,20,30", hour=2, minute=0)),
-    beat('advisornotes.tasks.cleanup_advising_surveys', crontab(minute=0, hour='2')),
-    beat('advisornotes.tasks.program_info_for_advisorvisits', crontab(minute=5, hour='2')),
+    beat('coredata.tasks.expire_sessions_conveniently', crontab(minute='0', hour=h(4))),
+    beat('coredata.tasks.haystack_rebuild', crontab(minute='0', hour=h(2), day_of_week='saturday'), queue='batch'),
+    beat('coredata.tasks.expiring_roles', crontab(minute='30', hour=h(7), day_of_week='mon,thu')),
+    beat('dashboard.tasks.photo_password_update_task', crontab(day_of_month="10,20,30", hour=h(2), minute=0)),
+    beat('advisornotes.tasks.cleanup_advising_surveys', crontab(minute=0, hour=h(2))),
+    beat('advisornotes.tasks.program_info_for_advisorvisits', crontab(minute=5, hour=h(2))),
     beat('forum.tasks.send_digests', crontab(hour='*', minute='0')),
-    beat('grad.tasks.update_statuses_to_current', crontab(minute=0, hour=3)),
-    beat('onlineforms.tasks.waiting_forms_reminder', crontab(day_of_week="1", hour="13", minute="0")),
-    beat('onlineforms.tasks.reject_dormant_initial', crontab(hour="18", minute="0")),
-    beat('ra.tasks.expiring_ras_reminder', crontab(minute='0', hour='13')),
-    beat('reminders.tasks.daily_reminders', crontab(minute='0', hour='9')),
-    beat('reports.tasks.run_regular_reports', crontab(hour=9, minute=15)),
-    beat('ta.tasks.check_and_execute_reminders', crontab(minute='0', hour='8')),
+    beat('grad.tasks.update_statuses_to_current', crontab(minute=0, hour=h(3))),
+    beat('onlineforms.tasks.waiting_forms_reminder', crontab(day_of_week="1", hour=h(13), minute="0")),
+    beat('onlineforms.tasks.reject_dormant_initial', crontab(hour=h(18), minute="0")),
+    beat('ra.tasks.expiring_ras_reminder', crontab(minute='0', hour=h(13))),
+    beat('reminders.tasks.daily_reminders', crontab(minute='0', hour=h(9))),
+    beat('reports.tasks.run_regular_reports', crontab(hour=h(9), minute=15), queue='sims'),
+    beat('ta.tasks.check_and_execute_reminders', crontab(minute='0', hour=h(8))),
     beat('log.tasks.log_regular', crontab(hour='*', minute='0,15,30,45'), queue='fast'),
     beat('log.tasks.log_avg_request_duration', crontab(hour='*', minute=0), queue='fast'),
 ])

--- a/courses/settings.py
+++ b/courses/settings.py
@@ -49,7 +49,7 @@ INSTALLED_APPS = (
     'compressor',
     'haystack',
     'djcelery_email',
-    'django_celery_beat',
+    # 'django_celery_beat',
     'formtools',
     'coredata',
     'dashboard',
@@ -316,13 +316,13 @@ if USE_CELERY:
     CELERY_ACCEPT_CONTENT = ['json', 'pickle']
     CELERY_TASK_SERIALIZER = 'json'
     CELERY_RESULT_SERIALIZER = 'json'
-    CELERY_BEAT_SCHEDULER = 'django_celery_beat.schedulers:DatabaseScheduler'
+    #CELERY_BEAT_SCHEDULER = 'django_celery_beat.schedulers:DatabaseScheduler'
     from courses import celery_schedule
     CELERY_BEAT_SCHEDULE = celery_schedule.CELERY_BEAT_SCHEDULE
     DJANGO_CELERY_BEAT_TZ_AWARE = USE_TZ
     CELERYD_TASK_SOFT_TIME_LIMIT = 1200
-    CELERY_ENABLE_UTC = False
-    CELERY_TIMEZONE = TIME_ZONE
+    CELERY_ENABLE_UTC = True
+    CELERY_TIMEZONE = 'UTC'
     CELERY_TASK_ALWAYS_EAGER = False
 
     CELERY_TASK_DEFAULT_QUEUE = 'batch'


### PR DESCRIPTION
This moves celery beat's storage (of when tasks were last run) from the django database to the default file-based storage, and converts periodic tasks to UTC. There have been long-standing bugs with these and the defaults (file-based storage and UTC) seem much more stable.