### PR TITLE
be more fault tolerant with server messages

### DIFF
--- a/courses/docker-localsettings-demo.py
+++ b/courses/docker-localsettings-demo.py
@@ -39,8 +39,3 @@ SERVER_MESSAGE = mark_safe('''<p class="warningmessage"><i class="fas fa-exclama
     This demo server is publicly available and unauthenticated: no confidential or personally-identifying information
     should be entered anywhere here.
 </p>''')
-
-if os.path.isfile('/dynamic_config/server_message_index.html'):
-    SERVER_MESSAGE_INDEX = mark_safe(open('/dynamic_config/server_message_index.html', 'rt', encoding='utf-8').read())
-if os.path.isfile('/dynamic_config/server_message.html'):
-    SERVER_MESSAGE = mark_safe(open('/dynamic_config/server_message.html', 'rt', encoding='utf-8').read())

--- a/courses/docker-localsettings-proddev.py
+++ b/courses/docker-localsettings-proddev.py
@@ -33,8 +33,3 @@ except KeyError:
 
 # SERVER_MESSAGE_INDEX = mark_safe('''<p class="infomessage"><i class="fas fa-info-circle"></i> Info on the index page.</p>''')
 # SERVER_MESSAGE = mark_safe('''<p class="warningmessage"><i class="fas fa-exclamation-triangle"></i> Warning on every page</p>''')
-
-if os.path.isfile('/dynamic_config/server_message_index.html'):
-    SERVER_MESSAGE_INDEX = mark_safe(open('/dynamic_config/server_message_index.html', 'rt', encoding='utf-8').read())
-if os.path.isfile('/dynamic_config/server_message.html'):
-    SERVER_MESSAGE = mark_safe(open('/dynamic_config/server_message.html', 'rt', encoding='utf-8').read())

--- a/courses/docker-localsettings-production.py
+++ b/courses/docker-localsettings-production.py
@@ -33,8 +33,3 @@ EMPLID_API_SECRET = config['external']['emplid_api_secret']
 
 # SERVER_MESSAGE_INDEX = mark_safe('''<p class="infomessage"><i class="fas fa-info-circle"></i> Info on the index page.</p>''')
 # SERVER_MESSAGE = mark_safe('''<p class="warningmessage"><i class="fas fa-exclamation-triangle"></i> Warning on every page</p>''')
-
-if os.path.isfile('/dynamic_config/server_message_index.html'):
-    SERVER_MESSAGE_INDEX = mark_safe(open('/dynamic_config/server_message_index.html', 'rt', encoding='utf-8').read())
-if os.path.isfile('/dynamic_config/server_message.html'):
-    SERVER_MESSAGE = mark_safe(open('/dynamic_config/server_message.html', 'rt', encoding='utf-8').read())

--- a/dashboard/context.py
+++ b/dashboard/context.py
@@ -1,6 +1,8 @@
+from pathlib import Path
 import socket
 
 from django.conf import settings
+from django.utils.safestring import mark_safe
 from coredata.models import Member
 from cache_utils.decorators import cached
 from courselib.branding import product_name, help_email
@@ -12,6 +14,30 @@ def is_instr_ta(userid):
         return False
     members = Member.objects.filter(role__in=['INST', 'TA'])
     return members.exists()
+
+
+def get_server_message(config: str, filename: Path) -> str:
+    """
+    Find a server-wide message, if provided anywhere by admins.
+
+    If set (and non-empty) in settings.THE_CONFIG then use that.
+    If the file is present, read that and use it.
+    """
+    if hasattr(settings, config):
+        # if the message is set in settings.py, honour it.
+        cfg_msg = getattr(settings, config)
+        if len(cfg_msg) > 0:
+            return cfg_msg
+
+    try:
+        file_msg = open(filename, 'rt', encoding='utf-8').read()
+        return mark_safe(file_msg)
+    except FileNotFoundError as e:
+        return ''
+    except Exception as e:
+        # file unreadable: output something for gunicorn logs
+        print(f'Could not read server message {filename}: {e}')
+        return ''
 
 
 def media(request):
@@ -32,7 +58,7 @@ def media(request):
             'request_path': request.path,
             'CourSys': product_name(request),
             'help_email': help_email(request),
-            'SERVER_MESSAGE_INDEX': settings.SERVER_MESSAGE_INDEX,
-            'SERVER_MESSAGE': settings.SERVER_MESSAGE,
+            'SERVER_MESSAGE_INDEX': get_server_message('SERVER_MESSAGE_INDEX', Path('/dynamic_config/server_message_index.html')),
+            'SERVER_MESSAGE': get_server_message('SERVER_MESSAGE', Path('/dynamic_config/server_message.html')),
             'SERVER_HOSTNAME': socket.gethostname(),
             }


### PR DESCRIPTION
This changes the handling of the `/dynamic_config/*.html` server-wide messages: moves them  out of the localsettings where they were ugly, and into the context processor where they are used. We can be more consistent and fault-tolerant that way.